### PR TITLE
Dates model bug and improvements

### DIFF
--- a/lib/PimcoreNotifications/Model/Notification.php
+++ b/lib/PimcoreNotifications/Model/Notification.php
@@ -324,11 +324,33 @@ class Notification extends AbstractModel
     }
 
     /**
+     * @param int $creationDate
+     *
+     * @return $this
+     */
+    public function setCreationDate($creationDate)
+    {
+        $this->creationDate = $creationDate;
+        return $this;
+    }
+
+    /**
      * @return int
      */
     public function getModificationDate()
     {
         return $this->modificationDate;
+    }
+
+    /**
+     * @param int $modificationDate
+     *
+     * @return $this
+     */
+    public function setModificationDate($modificationDate)
+    {
+        $this->modificationDate = $modificationDate;
+        return $this;
     }
 
     /**

--- a/static/js/portlet.js
+++ b/static/js/portlet.js
@@ -30,7 +30,7 @@ pimcore.layout.portlets.notifications = Class.create(pimcore.layout.portlets.abs
             {header: "ID", flex: 1, sortable: false, hidden: true, dataIndex: 'id'},
             {
                 header: t("title"),
-                flex: 6,
+                flex: 4,
                 sortable: false,
                 dataIndex: 'title',
                 renderer: function (val, metaData, record, rowIndex, colIndex, store) {
@@ -42,7 +42,24 @@ pimcore.layout.portlets.notifications = Class.create(pimcore.layout.portlets.abs
                 }
             },
             {header: t("from"), flex: 2, sortable: false, dataIndex: 'from'},
-            {header: t("date"), flex: 3, sortable: false, dataIndex: 'date'},
+            {header: t("date"), flex: 2, sortable: false, dataIndex: 'date'},
+            {
+                header: t("element"),
+                xtype: 'actioncolumn',
+                flex: 0.5,
+                items: [
+                    {
+                        tooltip: t('open_linked_element'),
+                        icon: "/pimcore/static6/img/flat-color-icons/cursor.svg",
+                        handler: function (grid, rowIndex) {
+                            pimcore.plugin.notifications.helpers.openLinkedElement(grid.getStore().getAt(rowIndex).data);
+                        }.bind(this),
+                        isDisabled: function (grid, rowIndex) {
+                            return !parseInt(grid.getStore().getAt(rowIndex).data['linkedElementId']);
+                        }.bind(this)
+                    }
+                ]
+            },
             {
                 xtype: 'actioncolumn',
                 flex: 1,
@@ -51,7 +68,7 @@ pimcore.layout.portlets.notifications = Class.create(pimcore.layout.portlets.abs
                         tooltip: t('open'),
                         icon: "/pimcore/static6/img/flat-color-icons/right.svg",
                         handler: function (grid, rowIndex) {
-                            this.openDetails(grid.getStore().getAt(rowIndex).get("id"));
+                            pimcore.plugin.notifications.helpers.openDetails(grid.getStore().getAt(rowIndex).get("id"));
                         }.bind(this)
                     },
                     {

--- a/static/js/portlet.js
+++ b/static/js/portlet.js
@@ -36,7 +36,7 @@ pimcore.layout.portlets.notifications = Class.create(pimcore.layout.portlets.abs
                 renderer: function (val, metaData, record, rowIndex, colIndex, store) {
                     var unread = parseInt(store.getAt(rowIndex).get("unread"));
                     if (unread) {
-                        return '<strong>' + val + '</strong>';
+                        return '<strong style="font-weight: bold;">' + val + '</strong>'; // css style need to be added
                     }
                     return val;
                 }

--- a/static/js/startup.js
+++ b/static/js/startup.js
@@ -13,7 +13,7 @@ pimcore.plugin.notifications = Class.create(pimcore.plugin.admin, {
     },
 
     startAjaxConnection: function () {
-        pimcore["intervals"]["checkNewNotification"] = window.setInterval(function () {
+        function runAjaxConnection () {
             Ext.Ajax.request({
                 url: "/plugin/PimcoreNotifications/index/unread?interval=" + 30,
                 success: function (response) {
@@ -22,7 +22,12 @@ pimcore.plugin.notifications = Class.create(pimcore.plugin.admin, {
                     pimcore.plugin.notifications.helpers.showNotifications(data.data);
                 }
             });
+        }
+        
+        pimcore["intervals"]["checkNewNotification"] = window.setInterval(function (elt) {
+            runAjaxConnection();
         }, 30000);
+        runAjaxConnection(); // run at the Pimcore login
     },
 
     startConnection: function () {
@@ -31,7 +36,9 @@ pimcore.plugin.notifications = Class.create(pimcore.plugin.admin, {
             success: function (response) {
                 var data = Ext.decode(response.responseText);
 
-                this.socket = new WebSocket("ws://" + location.host + ":8080/?token=" + data['token'] + "&user=" + data['user']);
+                var websocketProtocol = "ws:";
+                if (location.protocol === "https:") websocketProtocol = "wss:";
+                this.socket = new WebSocket(websocketProtocol + "//" + location.host + ":8080/?token=" + data['token'] + "&user=" + data['user']);
                 this.socket.onopen = function (event) {
                 };
                 this.socket.onclose = function (event) {

--- a/texts/fr.csv
+++ b/texts/fr.csv
@@ -1,0 +1,5 @@
+pimcore_status_notification,Notifications
+mark_as_read,Marqué comme lu
+notifications,Notifications
+delete_all,Supprimer tout
+open_linked_element,Ouvrir élément


### PR DESCRIPTION
Hello,

This pull request correct a problem with dateCreation and dateModification (no setters in the model) with cause getCreationDate to be null and zend to convert them to current date on the grid (panel/portlet) list.

Some improvements are added:
- on "Delete all" action a confirm box is show to prevent false action
- by default notification list is ordered by creationDate DESC like a webmail
- sorting and filtering on the grid list has been added to search easily through notifications
- security check have been added to be sure other user cannot read messages (by forcing post parameters for instance)
- message unread are now in bold for panel and portlet (strong tag was not enough - Firefox)
- element can be directly opened from panel or portlet
- websocket send no more security warning/blocking if https is used for Pimcore backend (this error was fatal and the ajaxConnection fallback was not runned)
- if no websocket, ajaxConnection is run a firsttime before the setInterval (so as the user log in Pimcore he don't have to wait 30s to see new message)
- french translation added

If it could be merged it would be great!

Thanks.
